### PR TITLE
Control d'errors al registrar nou usuari

### DIFF
--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -5,6 +5,9 @@ import Typography from '@material-ui/core/Typography'
 import { makeStyles } from '@material-ui/core/styles'
 import { register, currentUser } from 'services/api'
 import { useAuth } from 'context/currentUser'
+import SimpleSnackbar from 'components/SimpleSnackbar'
+import Snackbar from '@material-ui/core/Snackbar'
+import Alert from '@material-ui/lab/Alert'
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -37,6 +40,7 @@ function Register(props) {
   const [msgError, setmsgError] = useState('')
   const [isPasswdInvalid, setPasswdInvalid] = useState(false)
   const { setCurrentUser } = useAuth()
+  const [showAlert, setShowAlert] = useState()
 
   const handleSubmit = (event) => {
     event.preventDefault()
@@ -51,6 +55,7 @@ function Register(props) {
             .catch((error) => {})
         })
         .catch((error) => {
+          setShowAlert(true)
           switch (error?.message) {
             case 'Network Error':
               setmsgError("No s'ha pogut connectar amb el servidor")
@@ -146,6 +151,9 @@ function Register(props) {
         >
           Ja tens usuari? <u>Entra</u>
         </Typography>
+        <Snackbar open={showAlert} autoHideDuration={60}>
+          <Alert severity="error">{msgError}</Alert>
+        </Snackbar>
       </div>
     </>
   )

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -34,6 +34,7 @@ function Register(props) {
   const [password, setPassword] = useState()
   const [repeatPassword, setRepeatPassword] = useState()
   const [isInvalid, setisInvalid] = useState(false)
+  const [msgError, setmsgError] = useState('')
   const [isPasswdInvalid, setPasswdInvalid] = useState(false)
   const { setCurrentUser } = useAuth()
 
@@ -50,6 +51,17 @@ function Register(props) {
             .catch((error) => {})
         })
         .catch((error) => {
+          switch (error?.message) {
+            case 'Network Error':
+              setmsgError("No s'ha pogut connectar amb el servidor")
+              break
+            case 'Request failed with status code 409':
+              setmsgError("L'usuari ja existeix")
+              break
+            default:
+              console.log(error?.message)
+              setmsgError('Error desconegut')
+          }
           setisInvalid(true)
           props.setToken('')
         })
@@ -66,7 +78,7 @@ function Register(props) {
             variant="outlined"
             margin="normal"
             error={isInvalid}
-            helperText={isInvalid && "Aquest nom d'usuari ja existeix"}
+            helperText={isInvalid && msgError}
             required
             fullWidth
             id="username"

--- a/src/components/SimpleSnackbar.js
+++ b/src/components/SimpleSnackbar.js
@@ -22,7 +22,7 @@ function SimpleSnackbar(props) {
           vertical: 'bottom',
           horizontal: 'right',
         }}
-        open={console.log(alertInfo?.open) && alertInfo?.open}
+        open={alertInfo?.open}
         onClose={handleClose}
         message={alertInfo?.message}
         autoHideDuration={3000}

--- a/src/components/SimpleSnackbar.js
+++ b/src/components/SimpleSnackbar.js
@@ -22,7 +22,7 @@ function SimpleSnackbar(props) {
           vertical: 'bottom',
           horizontal: 'right',
         }}
-        open={alertInfo?.open}
+        open={console.log(alertInfo?.open) && alertInfo?.open}
         onClose={handleClose}
         message={alertInfo?.message}
         autoHideDuration={3000}


### PR DESCRIPTION
# Comportament antic

Independentment de l'error, alhora de registrar un usuari, sempre deia que l'usuari ja existia.

# Comportament nou

Mostra l'error concret en cada cas, i si no està controlat, el propaga cap a la interfície.