### PR TITLE
change editor mode to classic and acordion expanded

### DIFF
--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -81,7 +81,7 @@ function RichTextEditor(props) {
                 height={'auto'}
                 setOptions={{
                   buttonList: editorButtons,
-                  mode: 'inline',
+                  mode: 'classic',
                 }}
               />
             )) || (

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -98,7 +98,7 @@ function Editor(props) {
         enabledFields={data?.allowed_fields}
         headers={headersData}
       />
-      <Accordion>
+      <Accordion defaultExpanded>
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
           aria-controls="panel1a-content"


### PR DESCRIPTION
MIllora alguns aspectes d'usabilitat:
 - En obrir un editor, per defecte l'acordió que conté el cos del correu està expandit.
 - El mode de l'editor ara és clàssic (barra d'eines fixe):

    ![image](https://user-images.githubusercontent.com/57089889/180186465-04494cdf-4c7a-40d1-8bca-7ec5735663d5.png)
