### PR TITLE
Fix bug when clicking new added template

### DIFF
--- a/src/containers/NewTemplateForm.js
+++ b/src/containers/NewTemplateForm.js
@@ -60,7 +60,7 @@ function NewTemplateForm(props) {
         if (error.response?.status === 404) {
           setAlertInfo({
             open: true,
-            message: "No s'ha trobat l'XML ID",
+            message: "No s'ha trobat l'ID Semàntic",
             severity: 'error',
           })
         }
@@ -81,7 +81,7 @@ function NewTemplateForm(props) {
               {text}
             </Typography>
           </div>
-          <TemplateInfo item={data.template} />
+          <TemplateInfo item={data.template} setClicked={(e) => undefined} />
           <Button
             variant="outlined"
             onClick={(e) => {


### PR DESCRIPTION
Arreglar el bug  quan es fa click sobre una plantilla que s'acaba d'afegir. 

Canviar el text d'error quan no troba l'ID semàntic per fer-lo més comprensible