### PR TITLE
Added new defaultTag

### DIFF
--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -82,6 +82,7 @@ function RichTextEditor(props) {
                 setOptions={{
                   buttonList: editorButtons,
                   mode: 'classic',
+                  defaultTag: 'html_block',
                 }}
               />
             )) || (


### PR DESCRIPTION
- Que vol resoldre aquesta PR:
  - Quan entrem una plantilla nova, sovint ens trobem molts espais entre linies i si mirem el codi,  l'editor HTML ha afegit molts tags `<p>` cada un dels troços d'html que no es trobaven dins un tag html (excepte br, que també afegeix els `<p>`).

- Comportament antinc:
  - S'afegien `<p>` a per tot

- Comportament nou:
  - Hem creat un tag nou per defecte, que no modifica el format del correu.

- Targeta on es demana: https://trello.com/c/BfXuf4zN/5282-0-0-p22-ep263-ui-qmako-suneditor-genera-paragrafs-extra

