### PR TITLE
ADD Tinymce editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ UI-QMako allows for a user friendly editing of Mako Templates.
 
 ## Getting Started
 
-First, run the development server:
+Before running the server for the first time you should run the [npm postinstall script](#npm-postinstall) to set up TinyMCE editor.
+
+Then, run the development server:
 
 ```bash
 npm start
@@ -19,6 +21,10 @@ You can start editing the page by modifying `App.js`. The page auto-updates as y
 ## Available Scripts
 
 In the project directory, you can run:
+
+### `npm postinstall`
+
+To set up TinyMCE editor you should run this script after the installation.
 
 ### `npm start`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can start editing the page by modifying `App.js`. The page auto-updates as y
 
 In the project directory, you can run:
 
-### `npm postinstall`
+### `npm run postinstall`
 
 To set up TinyMCE editor you should run this script after the installation.
 

--- a/package.json
+++ b/package.json
@@ -9,19 +9,23 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
+    "@tinymce/tinymce-react": "^4.2.0",
     "axios": "^0.21.1",
+    "fs-extra": "^10.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "suneditor-react": "^2.16.3",
+    "tinymce": "^6.1.2",
     "web-vitals": "^1.1.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "postinstall": "node ./postinstall.js"
   },
   "eslintConfig": {
     "extends": [

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,5 @@
+const fse = require('fs-extra');
+const path = require('path');
+const topDir = __dirname;
+fse.emptyDirSync(path.join(topDir, 'public', 'tinymce'));
+fse.copySync(path.join(topDir, 'node_modules', 'tinymce'), path.join(topDir, 'public', 'tinymce'), { overwrite: true });

--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -1,8 +1,8 @@
-import { React, useState, useEffect } from 'react'
+import { React, useState, useEffect, useRef } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
-import SunEditor from 'suneditor-react'
-import 'suneditor/dist/css/suneditor.min.css' // Import Sun Editor's CSS File
 import { TextareaAutosize } from '@material-ui/core'
+
+import { Editor } from '@tinymce/tinymce-react'
 
 let editorButtons = [
   ['undo', 'redo'],
@@ -55,14 +55,14 @@ function RichTextEditor(props) {
   const [modifiedTexts, setModifiedTexts] = useState([[]])
   const classes = useStyles()
   const { data } = props
+  const editorRef = useRef(null)
 
   useEffect(() => {
     setModifiedTexts(data?.text?.by_type)
   }, [data?.meta_data?.id])
-
   const handleChange = (text, index) => {
     let modifiedTextsCopy = [...modifiedTexts]
-    modifiedTextsCopy[index][1] = text
+    modifiedTextsCopy[index][1] = editorRef.current.getContent()
     props.setEditorText(modifiedTextsCopy)
   }
   return (
@@ -71,17 +71,41 @@ function RichTextEditor(props) {
         modifiedTexts?.map(
           (item, index) =>
             (item[0] === 'html' && (
-              <SunEditor
-                key={index}
-                className={classes.editorComplex}
-                id={index}
-                setContents={item[1]}
+              <Editor
+                tinymceScriptSrc={
+                  process.env.PUBLIC_URL + '/tinymce/tinymce.min.js'
+                }
+                onInit={(evt, editor) => (editorRef.current = editor)}
+                initialValue={item[1]}
                 onChange={(e) => handleChange(e, index)}
-                setDefaultStyle="text-align: left; display: inline-block"
-                height={'auto'}
-                setOptions={{
-                  buttonList: editorButtons,
-                  mode: 'classic',
+                init={{
+                  menubar: false,
+                  plugins: [
+                    'advlist',
+                    'autolink',
+                    'lists',
+                    'link',
+                    'image',
+                    'charmap',
+                    'anchor',
+                    'searchreplace',
+                    'visualblocks',
+                    'code',
+                    'fullscreen',
+                    'insertdatetime',
+                    'media',
+                    'table',
+                    'preview',
+                    'help',
+                    'wordcount',
+                  ],
+                  toolbar:
+                    'undo redo | blocks | ' +
+                    'bold italic forecolor | alignleft aligncenter ' +
+                    'alignright alignjustify | bullist numlist outdent indent | ' +
+                    'removeformat | help',
+                  content_style:
+                    'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
                 }}
               />
             )) || (

--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -55,16 +55,18 @@ function RichTextEditor(props) {
   const [modifiedTexts, setModifiedTexts] = useState([[]])
   const classes = useStyles()
   const { data } = props
-  const editorRef = useRef(null)
+  const editorRef = useRef({})
 
   useEffect(() => {
     setModifiedTexts(data?.text?.by_type)
   }, [data?.meta_data?.id])
+
   const handleChange = (text, index) => {
     let modifiedTextsCopy = [...modifiedTexts]
-    modifiedTextsCopy[index][1] = editorRef.current.getContent()
+    modifiedTextsCopy[index][1] = editorRef.current[index].getContent()
     props.setEditorText(modifiedTextsCopy)
   }
+
   return (
     <div className={classes.editorsList}>
       {modifiedTexts?.length > 0 &&
@@ -72,12 +74,14 @@ function RichTextEditor(props) {
           (item, index) =>
             (item[0] === 'html' && (
               <Editor
+                id={index}
+                key={index}
                 tinymceScriptSrc={
                   process.env.PUBLIC_URL + '/tinymce/tinymce.min.js'
                 }
-                onInit={(evt, editor) => (editorRef.current = editor)}
-                initialValue={item[1]}
-                onChange={(e) => handleChange(e, index)}
+                onInit={(evt, editor) => (editorRef.current[index] = editor)}
+                value={item[1]}
+                onEditorChange={(e) => handleChange(e, index)}
                 init={{
                   menubar: false,
                   plugins: [
@@ -98,12 +102,14 @@ function RichTextEditor(props) {
                     'preview',
                     'help',
                     'wordcount',
+                    'code',
                   ],
                   toolbar:
                     'undo redo | blocks | ' +
-                    'bold italic forecolor | alignleft aligncenter ' +
+                    'bold italic backcolor forecolor | alignleft aligncenter ' +
                     'alignright alignjustify | bullist numlist outdent indent | ' +
-                    'removeformat | help',
+                    'removeformat | help |' +
+                    'image code',
                   content_style:
                     'body { font-family:Helvetica,Arial,sans-serif; font-size:14px }',
                 }}

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -148,7 +148,10 @@ function Editor(props) {
           <Button
             color="secundary"
             variant="contained"
-            onClick={(e) => history.push(`/edit/complex/${id}`)}
+            onClick={(e) => {
+              saveChanges(e)
+              history.push(`/edit/complex/${id}`)
+            }}
           >
             Editor HTML
           </Button>

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -158,6 +158,7 @@ function Editor(props) {
             variant="contained"
             disabled={!currentUser?.allowed_fields?.includes('python')}
             onClick={(e) => {
+              saveChanges(e)
               history.push(`/edit/simple/${id}`)
             }}
           >

--- a/src/containers/SingleTemplate.js
+++ b/src/containers/SingleTemplate.js
@@ -51,6 +51,7 @@ const useStyles = makeStyles((theme) => ({
     '&:hover, &:focus': {
       backgroundColor: 'transparent',
     },
+    justifyContent: 'center',
   },
   fabListItem: {
     pointerEvents: 'auto',
@@ -196,7 +197,7 @@ function SingleTemplate(props) {
                       <Fab
                         className={classes.fabListItem}
                         color="primary"
-                        variant="contained"
+                        variant="extended"
                         disabled={
                           !currentUser?.allowed_fields?.includes('python')
                         }
@@ -216,7 +217,7 @@ function SingleTemplate(props) {
                       <Fab
                         className={classes.fabListItem}
                         color="primary"
-                        variant="contained"
+                        variant="extended"
                         id="0"
                         onClick={(e) => setChosenEditor('complex')}
                       >


### PR DESCRIPTION
**Comportament antic:**

- El `SunEditor` trancava el format de moltes plantilles
- El format del menú despelgable de botons del container `SingleTemplate` estava trancat
- Els botons de l'editor per canviar a l'editor simple i l'editor HTML no guardaven els canvis

**Comportament nou:**

- S'ha substituit el SunEditor per `TinyMCE`
- L'estil dels botons torna a ser el correcte
- Els botons de l'editor per canviar a l'editor simple i l'editor HTML guarden els canvis

**Targeta on es demana:**

https://trello.com/c/BfXuf4zN/5282-0-0-p22-ep263-ui-qmako-suneditor-genera-paragrafs-extra