### PR TITLE
🐛 Fix get templates loop

### DIFF
--- a/src/containers/TemplateModelList.js
+++ b/src/containers/TemplateModelList.js
@@ -8,17 +8,6 @@ function TemplateModelList() {
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    getTemplateList()
-      .then((response) => {
-        setData(response)
-        setIsLoading(false)
-      })
-      .catch((error) => {
-        setIsLoading(false)
-      })
-  }, [data])
-
-  useEffect(() => {
     let dict = {} // create an empty array
 
     for (let i = 0; i < data.length; i++) {

--- a/src/containers/TemplateModelList.js
+++ b/src/containers/TemplateModelList.js
@@ -7,15 +7,26 @@ function TemplateModelList() {
   const [templateModelData, setTemplateModelData] = useState([])
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  const getTemplateModelData = (response) => {
     let dict = {} // create an empty array
-
-    for (let i = 0; i < data.length; i++) {
-      dict[data[i].model] = data[i].model in dict ? dict[data[i].model] + 1 : 1
+    for (let i = 0; i < response.length; i++) {
+      dict[response[i].model] =
+        response[i].model in dict ? dict[response[i].model] + 1 : 1
     }
-
     setTemplateModelData(dict)
-  }, [data])
+  }
+
+  useEffect(() => {
+    getTemplateList()
+      .then((response) => {
+        setData(response)
+        setIsLoading(false)
+        getTemplateModelData(response)
+      })
+      .catch((error) => {
+        setIsLoading(false)
+      })
+  }, [])
 
   return (
     <div>


### PR DESCRIPTION
## Description

We were calling the `getTemplatesList` endpoint from two different places, and one of them was calling it every time the data we were updating was refreshed.

## Changes

- Removed one of the `getTemplatesList` call in `TemplateModelList`

## Please, review

- That the templates are being loaded as we expect.



