### PR TITLE
Improvements in edit transfer and editor switch bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tinymce/tinymce-react": "^4.2.0",
         "axios": "^0.21.1",
         "fs-extra": "^10.1.0",
+        "material-ui-confirm": "^2.1.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-i18next": "^11.18.4",
@@ -13463,6 +13464,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/material-ui-confirm": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/material-ui-confirm/-/material-ui-confirm-2.1.4.tgz",
+      "integrity": "sha512-n0R0nLNpeTVuyxniDQ0gvXS19tAfNC6EpFe4Q0VfZ9J2GCKtzJQ7n/JNAD8XGTdFAzCky0yuBj9qTBRi5A4XgA==",
+      "peerDependencies": {
+        "@material-ui/core": ">= 3.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/md5.js": {
@@ -32390,6 +32401,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "material-ui-confirm": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/material-ui-confirm/-/material-ui-confirm-2.1.4.tgz",
+      "integrity": "sha512-n0R0nLNpeTVuyxniDQ0gvXS19tAfNC6EpFe4Q0VfZ9J2GCKtzJQ7n/JNAD8XGTdFAzCky0yuBj9qTBRi5A4XgA==",
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tinymce/tinymce-react": "^4.2.0",
     "axios": "^0.21.1",
     "fs-extra": "^10.1.0",
+    "material-ui-confirm": "^2.1.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.18.4",

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import theme from 'styles/theme'
 // import { CurrentUserProvider } from 'context/currentUser'
 import { SessionProvider, useAuth } from 'context/sessionContext'
 import { AlertInfoProvider } from 'context/alertDetails'
+import { ConfirmProvider } from 'material-ui-confirm'
 
 function App(props) {
   const alertProps = {
@@ -34,9 +35,11 @@ function App(props) {
       <ThemeProvider theme={theme}>
         <SessionProvider>
           <AlertInfoProvider alertProps={{ ...initAlert }}>
-            <Suspense fallback={<></>}>
-              <Routes />
-            </Suspense>
+            <ConfirmProvider>
+              <Suspense fallback={<></>}>
+                <Routes />
+              </Suspense>
+            </ConfirmProvider>
             <SimpleSnackbar alertProps={alertProps} />
           </AlertInfoProvider>
         </SessionProvider>

--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -1,6 +1,7 @@
 import { React, useState, useEffect, useRef } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { TextareaAutosize } from '@material-ui/core'
+import PropTypes from 'prop-types'
 
 import { Editor } from '@tinymce/tinymce-react'
 
@@ -112,6 +113,17 @@ function RichTextEditor(props) {
         )}
     </div>
   )
+}
+
+RichTextEditor.propTypes = {
+  data: PropTypes.shape({
+    text: PropTypes.shape({
+      by_type: PropTypes.array,
+    }),
+    meta_data: PropTypes.shape({
+      id: PropTypes.number,
+    }),
+  }).isRequired,
 }
 
 export default RichTextEditor

--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -33,7 +33,7 @@ function RichTextEditor(props) {
 
   useEffect(() => {
     setModifiedTexts(data?.text?.by_type)
-  }, [data?.meta_data?.id])
+  }, [data?.meta_data?.id, data?.text?.by_type])
 
   const handleChange = (text, index, editorType) => {
     let modifiedTextsCopy = [...modifiedTexts]

--- a/src/components/SimpleEditor.js
+++ b/src/components/SimpleEditor.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import TextareaAutosize from '@material-ui/core/TextareaAutosize'
 import { makeStyles } from '@material-ui/core/styles'
+import PropTypes from 'prop-types'
 
 const useStyles = makeStyles((theme) => ({
   editor: {
@@ -34,6 +35,15 @@ function SimpleEditor(props) {
       }}
     />
   )
+}
+
+SimpleEditor.propTypes = {
+  data: PropTypes.shape({
+    text: PropTypes.shape({ def_body_text: PropTypes.string }),
+    meta_data: PropTypes.shape({
+      id: PropTypes.number,
+    }),
+  }).isRequired,
 }
 
 export default SimpleEditor

--- a/src/components/SimpleEditor.js
+++ b/src/components/SimpleEditor.js
@@ -18,7 +18,7 @@ function SimpleEditor(props) {
   const [modifiedText, setModifiedText] = useState('')
   useEffect(() => {
     setModifiedText(data?.text?.def_body_text)
-  }, [data?.meta_data?.id])
+  }, [data?.meta_data?.id, data?.text?.def_body_text])
   return (
     <TextareaAutosize
       value={modifiedText}

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -227,7 +227,6 @@ function Editor(props) {
           <Button
             color="secundary"
             variant="contained"
-            disabled={true}
             onClick={(e) => {
               changeEditor(e)
             }}
@@ -238,8 +237,7 @@ function Editor(props) {
           <Button
             color="secundary"
             variant="contained"
-            disabled={true}
-            // disabled={!currentUser?.allowed_fields?.includes('python')}
+            disabled={!currentUser?.allowed_fields?.includes('python')}
             onClick={(e) => {
               changeEditor(e)
             }}

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { useParams, useHistory } from 'react-router-dom'
-import { startEditing, saveEditChanges, discardEditChanges } from 'services/api'
+import {
+  checkEdits,
+  startEditing,
+  saveEditChanges,
+  discardEditChanges,
+} from 'services/api'
 import TemplateHeaders from 'components/TemplateHeaders'
 import Accordion from '@material-ui/core/Accordion'
 import AccordionSummary from '@material-ui/core/AccordionSummary'
@@ -12,6 +17,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import SimpleEditor from '../components/SimpleEditor'
 import RichTextEditor from '../components/RichTextEditor'
 import CaseList from '../components/CaseList'
+import { useAlert } from 'context/alertDetails'
 
 //import { useAuth } from 'context/currentUser'
 import { useAuth } from 'context/sessionContext'
@@ -53,6 +59,7 @@ function Editor(props) {
   const [selectedCase, setSelectedCase] = useState(false)
   const [isNewEdit, setIsNewEdit] = useState(false)
   const history = useHistory()
+  const { setAlertInfo } = useAlert()
 
   const { currentUser } = useAuth()
 
@@ -78,15 +85,60 @@ function Editor(props) {
       .then((response) => {
         setSaveEditsResponse(response?.result)
         setIsNewEdit(false)
+        setAlertInfo({
+          open: true,
+          message: "L'edició s'ha guardat correctament.",
+          severity: 'success',
+        })
       })
-      .catch((error) => {})
+      .catch((error) => {
+        let message = 'Hi ha hagut un error al guardar.'
+        checkEdits(id)
+          .then((response) => {
+            if (response.current_edits[0].user_id !== currentUser.id) {
+              message = `L'edició és propietat de ${response.current_edits[0].user.username}`
+            }
+            setAlertInfo({
+              open: true,
+              message: message,
+              severity: 'error',
+            })
+          })
+          .catch((error) => {
+            setAlertInfo({
+              open: true,
+              message: message,
+              severity: 'error',
+            })
+          })
+      })
   }
   const discardChanges = (e) => {
     discardEditChanges(id)
       .then((response) => {
         history.push('/')
       })
-      .catch((error) => {})
+      .catch((error) => {
+        let message = 'Hi ha hagut un error al guardar.'
+        checkEdits(id)
+          .then((response) => {
+            if (response.current_edits[0].user_id !== currentUser.id) {
+              message = `L'edició és propietat de ${response.current_edits[0].user.username}`
+            }
+            setAlertInfo({
+              open: true,
+              message: message,
+              severity: 'error',
+            })
+          })
+          .catch((error) => {
+            setAlertInfo({
+              open: true,
+              message: message,
+              severity: 'error',
+            })
+          })
+      })
   }
 
   return (

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -73,7 +73,10 @@ function Editor(props) {
         setIsNewEdit(response.created)
         setEditId(response['edit_id'])
         setText(response.text.def_body_text)
-        setHeadersdData(Object.assign({}, response.headers, response.meta_data))
+        setHeadersdData({
+          ...response.headers,
+          ...response.meta_data,
+        })
       })
       .catch((error) => {})
   }, [id])
@@ -144,13 +147,10 @@ function Editor(props) {
       setIsNewEdit(start_editing_response.created)
       setEditId(start_editing_response['edit_id'])
       setText(start_editing_response.text.def_body_text)
-      setHeadersdData(
-        Object.assign(
-          {},
-          start_editing_response.headers,
-          start_editing_response.meta_data
-        )
-      )
+      setHeadersdData({
+        ...start_editing_response.headers,
+        ...start_editing_response.meta_data,
+      })
       if (editor === 'complex') {
         setGroupEditorText([])
       }

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -50,7 +50,7 @@ const useStyles = makeStyles((theme) => ({
 function Editor(props) {
   const classes = useStyles()
   const { editor, id } = useParams()
-  const [data, setData] = useState([])
+  const [data, setData] = useState({})
   const [editorText, setText] = useState('')
   const [editId, setEditId] = useState('')
   const [groupEditorText, setGroupEditorText] = useState([])

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -123,37 +123,41 @@ function Editor(props) {
       .catch(handleEditError)
   }
 
-  const changeEditor = (e) => {
-    saveEditChanges(id, editorText, groupEditorText, headersData)
-      .then((response) => {
-        setSaveEditsResponse(response?.result)
-        setIsNewEdit(false)
-        setAlertInfo({
-          open: true,
-          message: "L'edició s'ha guardat correctament.",
-          severity: 'success',
-        })
-        startEditing(id)
-          .then((response) => {
-            setData(response)
-            setIsNewEdit(response.created)
-            setEditId(response['edit_id'])
-            setText(response.text.def_body_text)
-            setHeadersdData(
-              Object.assign({}, response.headers, response.meta_data)
-            )
-            if (editor === 'complex') {
-              /* When switching to the simple editor groupEditorText must be empty. Otherwise, the API will
-              always store this value (which the simple editor does not use) instead of the editorText value. */
-              setGroupEditorText([])
-            }
-            history.push(
-              `/edit/${editor === 'simple' ? 'complex' : 'simple'}/${id}`
-            )
-          })
-          .catch((error) => {})
+  const changeEditor = async (e) => {
+    try {
+      const save_response = await saveEditChanges(
+        id,
+        editorText,
+        groupEditorText,
+        headersData
+      )
+      setSaveEditsResponse(save_response?.result)
+      setIsNewEdit(false)
+      setAlertInfo({
+        open: true,
+        message: "L'edició s'ha guardat correctament.",
+        severity: 'success',
       })
-      .catch(handleEditError)
+
+      const start_editing_response = await startEditing(id)
+      setData(start_editing_response)
+      setIsNewEdit(start_editing_response.created)
+      setEditId(start_editing_response['edit_id'])
+      setText(start_editing_response.text.def_body_text)
+      setHeadersdData(
+        Object.assign(
+          {},
+          start_editing_response.headers,
+          start_editing_response.meta_data
+        )
+      )
+      if (editor === 'complex') {
+        setGroupEditorText([])
+      }
+      history.push(`/edit/${editor === 'simple' ? 'complex' : 'simple'}/${id}`)
+    } catch (error) {
+      handleEditError(error)
+    }
   }
 
   const discardChanges = (e) => {

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -54,7 +54,7 @@ function Editor(props) {
   const [editorText, setText] = useState('')
   const [editId, setEditId] = useState('')
   const [groupEditorText, setGroupEditorText] = useState([])
-  const [headersData, setHeadersdData] = useState({})
+  const [headersData, setHeadersData] = useState({})
   const [saveEditsResponse, setSaveEditsResponse] = useState([])
   const [openCaseDialog, setOpenCaseDialog] = useState(false)
   const [selectedCase, setSelectedCase] = useState(false)
@@ -73,7 +73,7 @@ function Editor(props) {
         setIsNewEdit(response.created)
         setEditId(response['edit_id'])
         setText(response.text.def_body_text)
-        setHeadersdData({
+        setHeadersData({
           ...response.headers,
           ...response.meta_data,
         })
@@ -147,7 +147,7 @@ function Editor(props) {
       setIsNewEdit(start_editing_response.created)
       setEditId(start_editing_response['edit_id'])
       setText(start_editing_response.text.def_body_text)
-      setHeadersdData({
+      setHeadersData({
         ...start_editing_response.headers,
         ...start_editing_response.meta_data,
       })
@@ -181,7 +181,7 @@ function Editor(props) {
         {headersData.name}
       </Typography>
       <TemplateHeaders
-        passChildData={setHeadersdData}
+        passChildData={setHeadersData}
         enabledFields={data?.allowed_fields}
         headers={headersData}
       />

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -193,6 +193,7 @@ function Editor(props) {
           <Button
             color="secundary"
             variant="contained"
+            disabled={true}
             onClick={(e) => {
               saveChanges(e)
               history.push(`/edit/complex/${id}`)
@@ -204,7 +205,8 @@ function Editor(props) {
           <Button
             color="secundary"
             variant="contained"
-            disabled={!currentUser?.allowed_fields?.includes('python')}
+            disabled={true}
+            // disabled={!currentUser?.allowed_fields?.includes('python')}
             onClick={(e) => {
               saveChanges(e)
               history.push(`/edit/simple/${id}`)

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -118,6 +118,35 @@ function Editor(props) {
       })
       .catch(handleEditError)
   }
+
+  const changeEditor = (e) => {
+    saveEditChanges(id, editorText, groupEditorText, headersData)
+      .then((response) => {
+        setSaveEditsResponse(response?.result)
+        setIsNewEdit(false)
+        setAlertInfo({
+          open: true,
+          message: "L'edició s'ha guardat correctament.",
+          severity: 'success',
+        })
+        startEditing(id)
+          .then((response) => {
+            setData(response)
+            setIsNewEdit(response.created)
+            setEditId(response['edit_id'])
+            setText(response.text.def_body_text)
+            setHeadersdData(
+              Object.assign({}, response.headers, response.meta_data)
+            )
+            history.push(
+              `/edit/${editor === 'simple' ? 'complex' : 'simple'}/${id}`
+            )
+          })
+          .catch((error) => {})
+      })
+      .catch(handleEditError)
+  }
+
   const discardChanges = (e) => {
     confirm({
       title: 'Confirmació',
@@ -195,8 +224,7 @@ function Editor(props) {
             variant="contained"
             disabled={true}
             onClick={(e) => {
-              saveChanges(e)
-              history.push(`/edit/complex/${id}`)
+              changeEditor(e)
             }}
           >
             Editor HTML
@@ -208,8 +236,7 @@ function Editor(props) {
             disabled={true}
             // disabled={!currentUser?.allowed_fields?.includes('python')}
             onClick={(e) => {
-              saveChanges(e)
-              history.push(`/edit/simple/${id}`)
+              changeEditor(e)
             }}
           >
             Editor Simple

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -87,7 +87,11 @@ function Editor(props) {
     let message = 'Hi ha hagut un error.'
     checkEdits(id)
       .then((response) => {
-        if (response.current_edits[0].user_id !== currentUser.id) {
+        if (
+          response?.current_edits &&
+          response?.current_edits.length > 0 &&
+          response.current_edits[0].user_id !== currentUser.id
+        ) {
           message = `L'edició és propietat de ${response.current_edits[0].user.username}`
         }
         setAlertInfo({

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -80,6 +80,28 @@ function Editor(props) {
     }
   }, [selectedCase, editId])
 
+  const handleEditError = (error) => {
+    let message = 'Hi ha hagut un error al guardar.'
+    checkEdits(id)
+      .then((response) => {
+        if (response.current_edits[0].user_id !== currentUser.id) {
+          message = `L'edició és propietat de ${response.current_edits[0].user.username}`
+        }
+        setAlertInfo({
+          open: true,
+          message: message,
+          severity: 'error',
+        })
+      })
+      .catch((error) => {
+        setAlertInfo({
+          open: true,
+          message: message,
+          severity: 'error',
+        })
+      })
+  }
+
   const saveChanges = (e) => {
     saveEditChanges(id, editorText, groupEditorText, headersData)
       .then((response) => {
@@ -91,54 +113,14 @@ function Editor(props) {
           severity: 'success',
         })
       })
-      .catch((error) => {
-        let message = 'Hi ha hagut un error al guardar.'
-        checkEdits(id)
-          .then((response) => {
-            if (response.current_edits[0].user_id !== currentUser.id) {
-              message = `L'edició és propietat de ${response.current_edits[0].user.username}`
-            }
-            setAlertInfo({
-              open: true,
-              message: message,
-              severity: 'error',
-            })
-          })
-          .catch((error) => {
-            setAlertInfo({
-              open: true,
-              message: message,
-              severity: 'error',
-            })
-          })
-      })
+      .catch(handleEditError)
   }
   const discardChanges = (e) => {
     discardEditChanges(id)
       .then((response) => {
         history.push('/')
       })
-      .catch((error) => {
-        let message = 'Hi ha hagut un error al guardar.'
-        checkEdits(id)
-          .then((response) => {
-            if (response.current_edits[0].user_id !== currentUser.id) {
-              message = `L'edició és propietat de ${response.current_edits[0].user.username}`
-            }
-            setAlertInfo({
-              open: true,
-              message: message,
-              severity: 'error',
-            })
-          })
-          .catch((error) => {
-            setAlertInfo({
-              open: true,
-              message: message,
-              severity: 'error',
-            })
-          })
-      })
+      .catch(handleEditError)
   }
 
   return (

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useConfirm } from 'material-ui-confirm'
 import { makeStyles } from '@material-ui/core/styles'
 import { useParams, useHistory } from 'react-router-dom'
 import {
@@ -63,6 +64,8 @@ function Editor(props) {
 
   const { currentUser } = useAuth()
 
+  const confirm = useConfirm()
+
   useEffect(() => {
     startEditing(id)
       .then((response) => {
@@ -81,7 +84,7 @@ function Editor(props) {
   }, [selectedCase, editId])
 
   const handleEditError = (error) => {
-    let message = 'Hi ha hagut un error al guardar.'
+    let message = 'Hi ha hagut un error.'
     checkEdits(id)
       .then((response) => {
         if (response.current_edits[0].user_id !== currentUser.id) {
@@ -116,11 +119,18 @@ function Editor(props) {
       .catch(handleEditError)
   }
   const discardChanges = (e) => {
-    discardEditChanges(id)
-      .then((response) => {
-        history.push('/')
-      })
-      .catch(handleEditError)
+    confirm({
+      title: 'Confirmació',
+      description: "S'eliminarà l'edició permanentment, vols continuar?",
+      confirmationText: 'Continuar',
+      cancellationText: 'Cancel·lar',
+    }).then(() => {
+      discardEditChanges(id)
+        .then((response) => {
+          history.push('/')
+        })
+        .catch(handleEditError)
+    })
   }
 
   return (
@@ -161,7 +171,7 @@ function Editor(props) {
             variant="outlined"
             onClick={(e) => discardChanges(e)}
           >
-            Descartar l'edició
+            Eliminar l'edició
           </Button>
         )}
 

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -138,6 +138,11 @@ function Editor(props) {
             setHeadersdData(
               Object.assign({}, response.headers, response.meta_data)
             )
+            if (editor === 'complex') {
+              /* When switching to the simple editor groupEditorText must be empty. Otherwise, the API will
+              always store this value (which the simple editor does not use) instead of the editorText value. */
+              setGroupEditorText([])
+            }
             history.push(
               `/edit/${editor === 'simple' ? 'complex' : 'simple'}/${id}`
             )

--- a/src/containers/TemplateList.js
+++ b/src/containers/TemplateList.js
@@ -1,7 +1,11 @@
 import { React, useEffect, useState } from 'react'
 import { useConfirm } from 'material-ui-confirm'
 import TemplateInfo from 'components/TemplateInfo'
-import { getTemplateList, getSingleTemplate } from 'services/api'
+import {
+  getTemplateList,
+  getSingleTemplate,
+  deleteTemplate,
+} from 'services/api'
 import { makeStyles } from '@material-ui/core/styles'
 import SingleTemplate from './SingleTemplate'
 import Modal from '@material-ui/core/Modal'
@@ -9,7 +13,6 @@ import { useAlert } from 'context/alertDetails'
 //import { useAuth } from 'context/currentUser'
 import { useAuth } from 'context/sessionContext'
 import { useParams, useHistory } from 'react-router-dom'
-import { deleteTemplate } from 'services/api'
 
 const useStyles = makeStyles((theme) => ({
   modal: {

--- a/src/containers/TemplateList.js
+++ b/src/containers/TemplateList.js
@@ -1,4 +1,5 @@
 import { React, useEffect, useState } from 'react'
+import { useConfirm } from 'material-ui-confirm'
 import TemplateInfo from 'components/TemplateInfo'
 import { getTemplateList, getSingleTemplate } from 'services/api'
 import { makeStyles } from '@material-ui/core/styles'
@@ -49,6 +50,7 @@ function TemplateList(props) {
   const classes = useStyles()
   const { setAlertInfo } = useAlert()
   const { currentUser, setCurrentUser } = useAuth()
+  const confirm = useConfirm()
 
   useEffect(() => {
     if (refreshData) {
@@ -114,15 +116,22 @@ function TemplateList(props) {
   }
 
   const handleDelete = async (event, item) => {
-    event.preventDefault()
-    deleteTemplate(item.id).then((response) => {
-      setAlertInfo({
-        open: true,
-        message: response?.message,
-        severity: response?.deleted ? 'success' : 'error',
+    confirm({
+      title: 'Confirmació',
+      description: "S'eliminarà la plantilla, vols continuar?",
+      confirmationText: 'Continuar',
+      cancellationText: 'Cancel·lar',
+    }).then(() => {
+      event.preventDefault()
+      deleteTemplate(item.id).then((response) => {
+        setAlertInfo({
+          open: true,
+          message: response?.message,
+          severity: response?.deleted ? 'success' : 'error',
+        })
       })
+      setRefreshData(true)
     })
-    setRefreshData(true)
   }
 
   return (


### PR DESCRIPTION
## Description

- Improvements in edit transfer
- Fix bugs in editor change

https://trello.com/c/d8uZP5ox/343-uiqmako-fer-el-transferir-nom%C3%A9s-disponible-per-a-admins

Related to https://github.com/Som-Energia/uiqmako-api/pull/18

## Changes

- Catch discard/save API calls errors and show error alerts
- Show confirmation alerts on success
- Ask confirmation on template or edit deletion
- Reload data when switching editors to show the updated text
- Set empty list to `groupEditorText` when switching to simple editor to fix save bug

