### PR TITLE
Add entity_encoding parameter to TinyMCE init

### DIFF
--- a/src/components/RichTextEditor.js
+++ b/src/components/RichTextEditor.js
@@ -65,6 +65,7 @@ function RichTextEditor(props) {
                   if (e.key === 'Tab') e.preventDefault()
                 }}
                 init={{
+                  entity_encoding: 'raw',
                   menubar: false,
                   plugins: [
                     'advlist',


### PR DESCRIPTION
## Description

TinyMCE was converting characters into HTML entities by default (e.g. `€` was converted into `&euro;`).

https://www.tiny.cloud/docs-3x/reference/Configuration3x/Configuration3x@entity_encoding/

## Changes

- Set `raw` encoding type.

## Observations

https://somenergia.openproject.com/projects/som-energia/work_packages/91/activity