### PR TITLE
Remove sources other than PROD

### DIFF
--- a/src/containers/NewTemplateForm.js
+++ b/src/containers/NewTemplateForm.js
@@ -16,12 +16,7 @@ import { List, ListItem, ListItemText, IconButton } from '@material-ui/core'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import TemplateInfo from 'components/TemplateInfo'
 
-// TODO: Download the list from api
-const sources = [
-  { key: 'PROD', description: 'Producció' },
-  { key: 'TESTING', description: 'Testing' },
-  { key: 'DUMMY', description: 'Simulat' },
-]
+const sources = [{ key: 'PROD', description: 'Producció' }]
 
 const useStyles = makeStyles((theme) => ({
   form_root: {},


### PR DESCRIPTION
## Description

Avoid importing templates other than from `PROD`, as this makes no sense from a user perspective and can cause confusion.

However, it is still possible to upload the changes to other sources (e.g. users import the updated version of the template from production, but are allowed to upload it to the test server before uploading it to production).

## Changes

- Remove `TESTING` and `DUMMY` sources when importing templates.

## Observations

https://somenergia.openproject.com/projects/som-energia/work_packages/91/activity
